### PR TITLE
Better explanation of enabling outside network access to the database

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -29,7 +29,7 @@ aws rds describe-db-instances | jq ".DBInstances[].VpcSecurityGroups[].VpcSecuri
 .. Enable inbound network traffic:
 +
 ```
-aws ec2 authorize-security-group-ingress --group-id <group-id> --protocol all --port 3006 --cidr 0.0.0.0/0
+aws ec2 authorize-security-group-ingress --group-id <group-id> --protocol tcp --port 3006 --cidr 0.0.0.0/0
 ```
 +
 . Get instance id:

--- a/readme.adoc
+++ b/readme.adoc
@@ -19,14 +19,14 @@ aws rds create-db-instance \
     --backup-retention-period 3 
 ```
 +
-. Create inbound role for the security group:
+. Allow inbound network traffic to the database subnet:
 .. Get security group id:
 +
 ```
 aws rds describe-db-instances | jq ".DBInstances[].VpcSecurityGroups[].VpcSecurityGroupId"
 ```
 +
-.. Add inbound role:
+.. Enable inbound network traffic:
 +
 ```
 aws ec2 authorize-security-group-ingress --group-id <group-id> --protocol all --port 3006 --cidr 0.0.0.0/0


### PR DESCRIPTION
I found the documentation for this project helpful in getting to understand how to set up my own RDS instance and making it accessible over the internet.

I feel like this commit more clearly explains the purpose of running `aws ec2 authorize-security-group-ingress` after creating the database instance.